### PR TITLE
Reduce house simp

### DIFF
--- a/us-congress/Makefile
+++ b/us-congress/Makefile
@@ -111,7 +111,7 @@ topo/us-congress.json: shp/us/congress.shp
 	../node_modules/.bin/topojson \
 		-o $@ \
 		-q 2000000 \
-		-s 0.000006 \
+		-s 0.0000009 \
 		-p CONG_DIST,CONG_REP,PARTY_AFF,STATE,STATE_FIPS \
 		--id-property=STATE_FIPS+CONG_DIST \
 		-- us_congress=$<


### PR DESCRIPTION
Increases topojson file size by ~30% but preserves important geometry features. 

House maps are under scrutiny for redistricting, so we should stay close to the original map files where possible.
